### PR TITLE
Cancel pending tasks waiting for session loss after lock is released.

### DIFF
--- a/aiozk/states.py
+++ b/aiozk/states.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import logging
 
 import asyncio
@@ -64,6 +65,17 @@ class SessionStateMachine(object):
                 self.futures[state].add(f)
 
         return f
+
+    def remove_waiting(self, future, *states):
+        for state in states:
+            self.futures[state].remove(future)
+
+    def waitings(self, *states):
+        futures = {}
+        for state in states:
+            futures[state] = copy.copy(self.futures[state])
+
+        return futures
 
     def __eq__(self, state):
         return self.current_state == state

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -8,7 +8,7 @@ docker-compose up --abort-on-container-exit
 if [ -z "$TRAVIS"]; then
     docker-compose down -v
 fi
-CODE=`docker-compose ps -q | xargs docker inspect -f '{{ .State.ExitCode }}' | grep -vE '(0|3|143)' | wc -l | tr -d ' '`
+CODE=`docker-compose ps -q | xargs -I{} docker inspect -f '{{ .State.ExitCode }}' {} | grep -vE '(0|3|143)' | wc -l | tr -d ' '`
 
 echo "Tests completed with exit code $CODE"
 


### PR DESCRIPTION
Everytime lock is acquired by calling this statement "async with
zk.recipes.Lock(path).acquire():", a task is created waiting for zookeeper
session loss. However that task is still pending after the lock is released. If
a daemon program keeps zookeeper session over a month while it is running,
there exist tons of pending tasks and it leads to resource leakage problem.