### PR TITLE
Change watch_loop not to use wait_for_events method because the previ…

### DIFF
--- a/aiozk/recipes/base_watcher.py
+++ b/aiozk/recipes/base_watcher.py
@@ -28,21 +28,36 @@ class BaseWatcher(Recipe):
         self.callbacks[path].add(callback)
 
         if path not in self.loops:
-            self.loops[path] = asyncio.ensure_future(self.watch_loop(path), loop=self.client.loop)
+            self.add_watch_loop(path)
 
     def remove_callback(self, path, callback):
         self.callbacks[path].discard(callback)
 
         if not self.callbacks[path]:
             self.callbacks.pop(path)
-            self.loops.pop(path).cancel()
+            self.discard_watch_loop(path)
+
+    def add_watch_loop(self, path):
+        log.debug('Add new watch loop for %s', path)
+        stop_event = asyncio.Event(loop=self.client.loop)
+        fut = asyncio.ensure_future(self.watch_loop(path, stop_event), loop=self.client.loop)
+        self.loops[path] = (fut, stop_event)
+
+    def discard_watch_loop(self, path):
+        log.debug('Discard watch loop of %s', path)
+        try:
+            fut, stop_event = self.loops.pop(path)
+        except KeyError:
+            pass
+        else:
+            stop_event.set()
 
     async def fetch(self, path):
         raise NotImplementedError
 
-    async def watch_loop(self, path):
-        while self.callbacks[path]:
-            log.debug("Fetching data for %s", path)
+    async def watch_loop(self, path, stop_event):
+        async def run_callbacks():
+            log.debug('Fetching data for %s', path)
             try:
                 result = await self.fetch(path)
             except exc.NoNode:
@@ -51,20 +66,32 @@ class BaseWatcher(Recipe):
                 log.exception('Exception in watch loop: {}'.format(e))
                 log.info('Waiting for safe state...')
                 await self.client.session.ensure_safe_state()
-                continue
-            except Exception:
-                log.exception('Not handled in watch loop:')
-                raise
+                return
+            except Exception as e:
+                log.exception('Not handled in watch loop: %s', e)
+                self.discard_watch_loop(path)
+                return
 
             for callback in self.callbacks[path].copy():
-                maybe_future(callback(result), loop=self.client.loop)
+                log.debug('run user callback %s', callback)
+                try:
+                    maybe_future(callback(result), loop=self.client.loop)
+                except Exception as e:
+                    log.warning('user watch callback %s raised an unknown exception: %s', callback, e)
+
             if WatchEvent.CREATED not in self.watched_events and result == exc.NoNode:
+                self.discard_watch_loop(path)
                 return
-            try:
-                await self.client.wait_for_events(self.watched_events, path)
-            except asyncio.CancelledError:
-                pass
-            except Exception as e:
-                log.exception('Not handled in wait_for_events:')
-                print('Not handled: {!r}'.format(e))
-                raise
+
+        def watch_callback(*args):
+            asyncio.ensure_future(run_callbacks(), loop=self.client.loop)
+
+        normalized_path = self.client.normalize_path(path)
+        for event_type in self.watched_events:
+            self.client.session.add_watch_callback(event_type, normalized_path, watch_callback)
+        try:
+            watch_callback()
+            await stop_event.wait()
+        finally:
+            for event_type in self.watched_events:
+                self.client.session.remove_watch_callback(event_type, normalized_path, watch_callback)


### PR DESCRIPTION
…ous implementation of watch_loop() has a race condition problem.

watch_loop() calls fetch() and then calls wait_for_events(). However before
wait_for_events() is called this situation can happen:
ExistsRequest -> (ExistsRequest is proccessed by server) -> SetDataRequest ->
SetDataResponse -> ExistsResponse -> GetDataRequest -> WatchEvent ->
GetDataResponse

Successive call to wait_for_events() awaits watch-event indefintely because
watch-event is already fired and forgot.

To solve this problem, modify watch_loop() to keep watch-callbacks always.