### PR TITLE
Cancel Heartbeat when closing the session

### DIFF
--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -333,5 +333,7 @@ class Session:
             self.state.transition_to(States.LOST)
         if self.conn:
             await self.conn.close(self.timeout)
+        if self.heartbeat_handle:
+            self.heartbeat_handle.cancel()
         self.closing = False
         self.started = False

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -335,5 +335,9 @@ class Session:
             await self.conn.close(self.timeout)
         if self.heartbeat_handle:
             self.heartbeat_handle.cancel()
+            self.heartbeat_handle = None
+        if self.heartbeat_task and not self.heartbeat_task.done():
+            self.heartbeat_task.cancel()
+            self.heartbeat_task = None
         self.closing = False
         self.started = False


### PR DESCRIPTION
Fixes the following error message:

```
Task was destroyed but it is pending!
task: <Task pending name='Task-179' coro=<Session.heartbeat() running at .../aiozk/session.py:240> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x10d01a340>()]>>
```