### PR TITLE
Use zookeeper 3.5.7 to build docker images

### DIFF
--- a/docker/zookeeper.dockerfile
+++ b/docker/zookeeper.dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt install -y \
         libyaml-dev \
         default-jdk-headless
 
-ENV ZOOKEEPER_VERSION 3.5.6
+ENV ZOOKEEPER_VERSION 3.5.7
 ENV ZOOKEEPER_PACKAGE apache-zookeeper-${ZOOKEEPER_VERSION}-bin
 RUN curl -sS http://apache.mirrors.pair.com/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PACKAGE}.tar.gz | tar -xzf - -C /opt \
   && mv /opt/${ZOOKEEPER_PACKAGE} /opt/zookeeper \


### PR DESCRIPTION
The URL for downloading zookeeper does not exist:
http://apache.mirrors.pair.com/zookeeper/zookeeper-3.5.6/apache-zookeeper-3.5.6-bin.tar.gz
Use 3.5.7 instead.