### PR TITLE
Fix double barrier znode leakage

### DIFF
--- a/aiozk/test/test_barrier.py
+++ b/aiozk/test/test_barrier.py
@@ -1,6 +1,7 @@
 import asyncio
-
 import pytest
+
+from aiozk import exc
 
 
 @pytest.mark.asyncio
@@ -12,7 +13,7 @@ async def test_barrier(zk, path):
         barrier = zk.recipes.Barrier(path)
         is_worker_started.set_result('ok')
         await barrier.wait()
-        assert is_lifted == True
+        assert is_lifted is True
 
     barrier = zk.recipes.Barrier(path)
     await barrier.create()
@@ -92,3 +93,17 @@ async def test_many_waiters(zk, path):
     asyncio.wait_for(drain(), timeout=5)
 
     assert pass_barrier == WORKER_NUM
+
+
+async def test_double_barrier_timeout(zk, path):
+    entered = False
+    MIN_WORKERS = 10
+    barrier = zk.recipes.DoubleBarrier(path, MIN_WORKERS)
+    with pytest.raises(exc.TimeoutError):
+        await barrier.enter(timeout=0.5)
+        entered = True
+
+    assert not entered
+
+    await zk.deleteall(path)
+


### PR DESCRIPTION
DoubleBarrier.enter() method can incur znode leakage when an exception raises inside the method.
So fix .enter() method to delete a znode before returning only if an exception raises.