### PR TITLE
barrier: Fix double barrier test code

### DIFF
--- a/aiozk/test/test_barrier.py
+++ b/aiozk/test/test_barrier.py
@@ -90,7 +90,7 @@ async def test_many_waiters(zk, path):
         async with cond:
             await cond.wait_for(lambda: worker_cnt == 0)
 
-    asyncio.wait_for(drain(), timeout=5)
+    await asyncio.wait_for(drain(), timeout=5)
 
     assert pass_barrier == WORKER_NUM
 

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -5,7 +5,7 @@ docker-compose up --abort-on-container-exit
 
 # check last docker-compose status
 # rabbit stops with 143 exit code
-if [ -z "$TRAVIS"]; then
+if [[ -z "$TRAVIS" ]]; then
     docker-compose down -v &
 fi
 CODE=`docker-compose ps -q | xargs -I{} docker inspect -f '{{ .State.ExitCode }}' {} | grep -vE '(0|3|143)' | wc -l | tr -d ' '`


### PR DESCRIPTION
This is a pull request for PR#56
I made a new branch for this PR at this repository directly.


asyncio.gather returns immediately when one of awaitables raises an
exception. So it is possible that the first task raises an exception at the
.enter() method before the last task deletes its znode. If it happens, the
assertion of that no children znodes fails.