### PR TITLE
Fix timeout accuracy of DoubleBarrier.leave

### DIFF
--- a/aiozk/__init__.py
+++ b/aiozk/__init__.py
@@ -5,3 +5,4 @@ from .client import ZKClient  # noqa
 from .protocol import WatchEvent  # noqa
 from .protocol.acl import ACL  # noqa
 from .retry import RetryPolicy  # noqa
+from .deadline import Deadline  # noqa

--- a/aiozk/deadline.py
+++ b/aiozk/deadline.py
@@ -1,0 +1,31 @@
+import time
+
+
+class Deadline:
+    """It is convenient to use this class instead of timeout variable if the
+    timeout variable is accessed multiple times inside a function.
+    """
+
+    def __init__(self, timeout):
+        if timeout is None:
+            self.deadline = None
+        else:
+            self.deadline = timeout + time.time()
+
+    @property
+    def timeout(self):
+        if self.deadline is None:
+            return None
+        else:
+            return self.deadline - time.time()
+
+    @property
+    def has_passed(self):
+        if self.deadline is None:
+            return False
+        else:
+            return self.deadline - time.time() <= 0
+
+    @property
+    def is_indefinite(self):
+        return True if self.deadline is None else False

--- a/aiozk/recipes/double_barrier.py
+++ b/aiozk/recipes/double_barrier.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class DoubleBarrier(SequentialRecipe):
+    ZNODE_LABEL = 'worker'
 
     def __init__(self, base_path, min_participants):
         super().__init__(base_path)
@@ -20,14 +21,12 @@ class DoubleBarrier(SequentialRecipe):
 
     async def enter(self, timeout=None):
         log.debug("Entering double barrier %s", self.base_path)
-        barrier_lifted = self.client.wait_for_events(
-            [WatchEvent.CREATED], self.sentinel_path
-        )
+        barrier_lifted = self.client.wait_for_events([WatchEvent.CREATED],
+                                                     self.sentinel_path)
 
         exists = await self.client.exists(path=self.sentinel_path, watch=True)
 
-        ZNODE_LABEL = 'worker'
-        await self.create_unique_znode(ZNODE_LABEL)
+        await self.create_unique_znode(self.ZNODE_LABEL)
 
         if exists:
             return
@@ -47,24 +46,27 @@ class DoubleBarrier(SequentialRecipe):
             except asyncio.TimeoutError:
                 raise exc.TimeoutError
         except Exception:
-            await self.delete_unique_znode_retry(ZNODE_LABEL)
+            await self.delete_unique_znode_retry(self.ZNODE_LABEL)
             raise
 
     async def leave(self, timeout=None):
         log.debug("Leaving double barrier %s", self.base_path)
-        owned_positions, participants = await self.analyze_siblings()
-        while len(participants) > 1:
-            if owned_positions["worker"] == 0:
+
+        while True:
+            owned_positions, participants = await self.analyze_siblings()
+            if not participants:
+                return
+
+            if len(participants) == 1:
+                await self.delete_unique_znode(self.ZNODE_LABEL)
+                try:
+                    await self.client.delete(self.sentinel_path)
+                except exc.NoNode:
+                    pass
+                return
+
+            if owned_positions[self.ZNODE_LABEL] == 0:
                 await self.wait_on_sibling(participants[-1], timeout)
             else:
-                await self.delete_unique_znode("worker")
+                await self.delete_unique_znode(self.ZNODE_LABEL)
                 await self.wait_on_sibling(participants[0], timeout)
-
-            owned_positions, participants = await self.analyze_siblings()
-
-        if len(participants) == 1 and "worker" in owned_positions:
-            await self.delete_unique_znode("worker")
-            try:
-                await self.client.delete(self.sentinel_path)
-            except exc.NoNode:
-                pass

--- a/aiozk/recipes/lock.py
+++ b/aiozk/recipes/lock.py
@@ -1,4 +1,4 @@
-from aiozk import exc
+from aiozk import exc, Deadline
 
 from .base_lock import BaseLock
 
@@ -6,10 +6,11 @@ from .base_lock import BaseLock
 class Lock(BaseLock):
 
     async def acquire(self, timeout=None):
+        deadline = Deadline(timeout)
         result = None
         while not result:
             try:
-                result = await self.wait_in_line("lock", timeout)
+                result = await self.wait_in_line("lock", deadline.timeout)
             except exc.SessionLost:
                 continue
         return result

--- a/aiozk/recipes/sequential.py
+++ b/aiozk/recipes/sequential.py
@@ -36,6 +36,9 @@ class SequentialRecipe(Recipe):
             if await self.client.exists(self.owned_paths[znode_label]):
                 raise exc.NodeExists
 
+        if '/' in znode_label:
+            raise ValueError('slash in label')
+
         path = self.sibling_path(znode_label + "-" + self.guid + "-")
 
         try:

--- a/aiozk/recipes/shared_lock.py
+++ b/aiozk/recipes/shared_lock.py
@@ -1,26 +1,27 @@
-from aiozk import exc
+from aiozk import exc, Deadline
 
 from .base_lock import BaseLock
 
 
 class SharedLock(BaseLock):
-
     async def acquire_read(self, timeout=None):
+        deadline = Deadline(timeout)
         result = None
         while not result:
             try:
                 result = await self.wait_in_line(
-                    "read", timeout, blocked_by=("write")
+                    "read", deadline.timeout, blocked_by=("write")
                 )
             except exc.SessionLost:
                 continue
         return result
 
     async def acquire_write(self, timeout=None):
+        deadline = Deadline(timeout)
         result = None
         while not result:
             try:
-                result = await self.wait_in_line("write", timeout)
+                result = await self.wait_in_line("write", deadline.timeout)
             except exc.SessionLost:
                 continue
         return result

--- a/aiozk/test/test_recipe.py
+++ b/aiozk/test/test_recipe.py
@@ -64,3 +64,26 @@ async def test_create_unique_znode_twice(zk, path):
     finally:
         await seq_recipe.delete_unique_znode('test')
         await zk.delete(path)
+
+
+@pytest.mark.asyncio
+async def test_get_siblings_relative_path(zk, path):
+    seq_recipe = SequentialRecipe(path)
+    seq_recipe.set_client(zk)
+
+    await seq_recipe.create_unique_znode('test')
+    try:
+        siblings = await seq_recipe.get_siblings()
+        assert siblings[0].startswith('test')
+    finally:
+        await seq_recipe.delete_unique_znode('test')
+        await zk.delete(path)
+
+
+@pytest.mark.asyncio
+async def test_prohibited_slash_in_label(zk, path):
+    seq_recipe = SequentialRecipe(path)
+    seq_recipe.set_client(zk)
+
+    with pytest.raises(ValueError):
+        await seq_recipe.create_unique_znode('test/test')


### PR DESCRIPTION
A process which created znode of lowest sequence number calls wait_on_sibling method multiple times in the loop, but the previous code does not subtract already spent time from given timeout.

Refactoring DoubleBarrier.leave based on the official zookeeper document.

Also some tests are added.
