### PR TITLE
test: Download zookeeper from apache archive instead of current/stable mirror

### DIFF
--- a/docker/zookeeper.dockerfile
+++ b/docker/zookeeper.dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y \
 
 ENV ZOOKEEPER_VERSION 3.5.7
 ENV ZOOKEEPER_PACKAGE apache-zookeeper-${ZOOKEEPER_VERSION}-bin
-RUN curl -sS http://apache.mirrors.pair.com/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PACKAGE}.tar.gz | tar -xzf - -C /opt \
+RUN curl -sS http://archive.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PACKAGE}.tar.gz | tar -xzf - -C /opt \
   && mv /opt/${ZOOKEEPER_PACKAGE} /opt/zookeeper \
   && chown -R root:root /opt/zookeeper
 


### PR DESCRIPTION
I found CI build failure. New zookeeper version came out so that apache-zookeeper-3.5.7-bin.tar.gz can not be downloaded from apache mirror site anymore.
It is obvious that this situation will repeat again. So why don't we use apache archive instead of mirror site?
