### PR TITLE
session: Fix not to create duplicated heartbeat task

### DIFF
--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -53,7 +53,10 @@ class Session:
 
         self.repair_loop_task = None
 
+        # asyncio.TimerHandle object
         self.heartbeat_handle = None
+        # asyncio.Task object
+        self.heartbeat_task = None
 
         self.watch_callbacks = collections.defaultdict(set)
 
@@ -236,7 +239,8 @@ class Session:
         self.heartbeat_handle = self.loop.call_later(timeout, self.create_heartbeat)
 
     def create_heartbeat(self):
-        self.loop.create_task(self.heartbeat())
+        if not self.heartbeat_task or self.heartbeat_task.done():
+            self.heartbeat_task = self.loop.create_task(self.heartbeat())
 
     async def heartbeat(self):
         if self.closing:

--- a/aiozk/test/conftest.py
+++ b/aiozk/test/conftest.py
@@ -11,6 +11,11 @@ HOST = os.environ.get('ZK_HOST', 'zk')
 
 
 @pytest.fixture
+def servers():
+    return HOST
+
+
+@pytest.fixture
 def event_loop(event_loop):
     event_loop.set_debug(True)
     yield event_loop


### PR DESCRIPTION
While heartbeat task is waiting for ping response, .set_heartbeat() method can be called and after a bit later the second heartbeat task is created.
But if there exist more than one heartbeat task, session state turns into SUSPENDED because KeyError raises inside connection.read_loop.

This patch fixes .create_heartbeat method not to create heartbeat task if there is already one.