### PR TITLE
Lock async context manager

### DIFF
--- a/aiozk/recipes/lock.py
+++ b/aiozk/recipes/lock.py
@@ -1,16 +1,48 @@
-from aiozk import exc, Deadline
-
+from .. import exc
+from ..deadline import Deadline
 from .base_lock import BaseLock
 
 
 class Lock(BaseLock):
+    def __init__(self, base_path, znode_label='lock', blocked_by=None):
+        super().__init__(base_path)
+        self.znode_label = znode_label
+        self.blocked_by = blocked_by
+        self.is_locked = False
+        # This lock is for coordination between processes through network. Not
+        # for tasks in a process. Simultaneous .acquire calls is misuse.
+        self.in_use = False
+
+    async def __aenter__(self):
+        await self.acquire()
+
+    async def __aexit__(self, exc_type, exception, tb):
+        await self.release()
 
     async def acquire(self, timeout=None):
+        if self.in_use:
+            raise RuntimeError('lock is already in use')
+        self.in_use = True
         deadline = Deadline(timeout)
-        result = None
-        while not result:
+        while not self.is_locked and not deadline.has_passed:
             try:
-                result = await self.wait_in_line("lock", deadline.timeout)
+                await self.wait_in_line(self.znode_label,
+                                        deadline.timeout,
+                                        blocked_by=self.blocked_by)
             except exc.SessionLost:
                 continue
-        return result
+            except Exception as e:
+                self.in_use = False
+                raise e from None
+
+            self.is_locked = True
+
+    async def release(self):
+        try:
+            await self.get_out_of_line(self.znode_label)
+        finally:
+            self.is_locked = False
+            self.in_use = False
+
+    def locked(self):
+        return self.is_locked

--- a/aiozk/test/test_lock.py
+++ b/aiozk/test/test_lock.py
@@ -30,52 +30,58 @@ async def test_creation_failure_deadlock(zk, path):
     with pytest.raises(TimeoutError):
         # lock is created at zookeeper but response can not be returned because
         # read loop task was cancelled.
-        async with await lock.acquire(timeout=2):
+        await lock.acquire(timeout=2)
+        try:
             lock_acquired = True
+        finally:
+            await lock.release()
 
     assert not lock_acquired
     assert not lock.owned_paths
 
     lock2 = zk.recipes.Lock(path)
     try:
-        async with await lock2.acquire(timeout=2):
+        await lock2.acquire(timeout=2)
+        try:
             lock_acquired = True
-
-        assert lock_acquired
+        finally:
+            await lock2.release()
     finally:
         await zk.deleteall(path)
+    assert lock_acquired
 
 
 @pytest.mark.asyncio
 async def test_acquisition_failure_deadlock(zk, path):
-    lock = zk.recipes.Lock(path)
-    await lock.ensure_path()
-
-    async with await lock.acquire(timeout=0.5):
+    async with zk.recipes.Lock(path):
         lock2 = zk.recipes.Lock(path)
         await lock2.ensure_path()
-
         lock2.analyze_siblings_orig = lock2.analyze_siblings
+
         # analyze_siblings() is called by .wait_in_line()
         async def analyze_siblings_fail(self):
             await self.analyze_siblings_orig()
             raise TimeoutError('fail', 1234)
 
         lock2.analyze_siblings = types.MethodType(analyze_siblings_fail, lock2)
-
         lock_acquired = False
         with pytest.raises(TimeoutError):
-            async with await lock2.acquire(timeout=0.5):
+            await lock2.acquire(timeout=0.5)
+            try:
                 lock_acquired = True
+            finally:
+                await lock2.release()
 
         assert not lock_acquired
 
     try:
-        lock3 = zk.recipes.Lock(path)
-        await lock.ensure_path()
         lock_acquired2 = False
-        async with await lock3.acquire(timeout=0.5):
+        lock3 = zk.recipes.Lock(path)
+        await lock3.acquire(timeout=1)
+        try:
             lock_acquired2 = True
+        finally:
+            await lock3.release()
 
         assert lock_acquired2
     finally:
@@ -84,28 +90,145 @@ async def test_acquisition_failure_deadlock(zk, path):
 
 @pytest.mark.asyncio
 async def test_timeout_accuracy(zk, path):
-    lock = zk.recipes.Lock(path)
+    try:
+        async with zk.recipes.Lock(path):
+            lock2 = zk.recipes.Lock(path)
+            analyze_siblings = lock2.analyze_siblings
+            lock2.analyze_siblings = asynctest.CoroutineMock()
 
-    async with await lock.acquire():
-        lock2 = zk.recipes.Lock(path)
-        analyze_siblings = lock2.analyze_siblings
-        lock2.analyze_siblings = asynctest.CoroutineMock()
+            async def slow_analyze():
+                await asyncio.sleep(0.5)
+                return await analyze_siblings()
 
-        async def slow_analyze():
-            await asyncio.sleep(0.5)
-            return await analyze_siblings()
+            lock2.analyze_siblings.side_effect = slow_analyze
 
-        lock2.analyze_siblings.side_effect = slow_analyze
+            acquired = False
+            start = time.perf_counter()
+            with pytest.raises(TimeoutError):
+                await lock2.acquire(timeout=0.5)
+                try:
+                    acquired = True
+                finally:
+                    await lock2.release()
 
-        acquired = False
-        start = time.perf_counter()
-        with pytest.raises(TimeoutError):
-            async with await lock2.acquire(timeout=0.5):
-                acquired = True
-
-        elapsed = time.perf_counter() - start
-
-    await zk.deleteall(path)
-
+            elapsed = time.perf_counter() - start
+    finally:
+        await zk.deleteall(path)
     assert not acquired
     assert elapsed < 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock(zk, path):
+    lock = zk.recipes.Lock(path)
+    acquired = False
+    try:
+        await lock.acquire(timeout=2)
+        try:
+            acquired = True
+            assert acquired
+        finally:
+            await lock.release()
+    finally:
+        await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager(zk, path):
+    acquired = False
+    try:
+        async with zk.recipes.Lock(path):
+            acquired = True
+            await asyncio.sleep(1)
+
+        assert acquired
+    finally:
+        await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_deadlock(zk, path):
+    acquired = False
+    acquired2 = False
+    try:
+        async with zk.recipes.Lock(path):
+            acquired = True
+
+            lock = zk.recipes.Lock(path)
+            with pytest.raises(TimeoutError):
+                await lock.acquire(timeout=1)
+                try:
+                    acquired2 = True
+                finally:
+                    await lock.release()
+    finally:
+        await zk.deleteall(path)
+
+    assert acquired
+    assert not acquired2
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_reentrance(zk, path):
+    """reentrance is not permitted"""
+    lock = zk.recipes.Lock(path)
+    acquired = False
+    acquired2 = False
+    try:
+        async with lock:
+            acquired = True
+            with pytest.raises(RuntimeError):
+                await lock.acquire()
+                acquired2 = True
+
+        assert acquired
+        assert not acquired2
+    finally:
+        await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_reuse(zk, path):
+    lock = zk.recipes.Lock(path)
+    acquired = False
+    acquired2 = False
+    try:
+        async with lock:
+            acquired = True
+            assert lock.locked()
+        assert not lock.locked()
+        async with lock:
+            acquired2 = True
+            assert lock.locked()
+        assert not lock.locked()
+        assert acquired
+        assert acquired2
+    finally:
+        await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_contention(zk, path):
+    CONTENDERS = 8
+    done = 0
+    cond = asyncio.Condition()
+
+    async def create_contender():
+        async with zk.recipes.Lock(path):
+            async with cond:
+                await asyncio.sleep(0.1)
+                nonlocal done
+                done += 1
+                cond.notify()
+
+    for _ in range(CONTENDERS):
+        asyncio.create_task(create_contender())
+
+    try:
+        async with cond:
+            await asyncio.wait_for(cond.wait_for(lambda: done == CONTENDERS),
+                                   timeout=2)
+
+        assert CONTENDERS == done
+    finally:
+        await zk.deleteall(path)

--- a/aiozk/test/test_shared_lock.py
+++ b/aiozk/test/test_shared_lock.py
@@ -9,13 +9,13 @@ async def test_shared_lock(zk, path):
 
     shared = zk.recipes.SharedLock(path)
     got_lock = False
-    async with await shared.acquire_write():
+    async with shared.writer_lock:
         got_lock = True
 
     assert got_lock
 
     got_released = False
-    async with await shared.acquire_write():
+    async with shared.writer_lock:
         got_released = True
 
     assert got_released
@@ -25,21 +25,141 @@ async def test_shared_lock(zk, path):
 @pytest.mark.asyncio
 async def test_shared_lock_timeout(zk, path):
     got_lock = False
-    async with await zk.recipes.SharedLock(path).acquire_write():
+    async with zk.recipes.SharedLock(path).writer_lock:
         got_lock = True
 
         with pytest.raises(TimeoutError):
-            await zk.recipes.SharedLock(path).acquire_write(timeout=1)
+            shrlock2 = zk.recipes.SharedLock(path)
+            await shrlock2.writer_lock.acquire(timeout=1)
 
     assert got_lock
 
     got_released = False
-    async with await zk.recipes.SharedLock(path).acquire_write():
+    async with zk.recipes.SharedLock(path).writer_lock:
         got_released = True
 
     assert got_released
 
     await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_multiple_reader_allowed(zk, path):
+    WORKERS = 8
+    counter = 0
+    cond = asyncio.Condition()
+
+    async def start_worker():
+        nonlocal counter
+        async with zk.recipes.SharedLock(path).reader_lock:
+            counter += 1
+            async with cond:
+                cond.notify()
+
+    async with zk.recipes.SharedLock(path).reader_lock:
+        try:
+            for _ in range(WORKERS):
+                asyncio.create_task(start_worker())
+            async with cond:
+                await asyncio.wait_for(
+                    cond.wait_for(lambda: counter == WORKERS), timeout=2)
+        finally:
+            await zk.deleteall(path)
+
+    assert counter == WORKERS
+
+
+@pytest.mark.asyncio
+async def test_reader_after_writer(zk, path):
+    counter = 0
+
+    async def start_reader_lock():
+        nonlocal counter
+        async with zk.recipes.SharedLock(path).reader_lock:
+            counter += 1
+            await asyncio.sleep(2)
+
+    async def start_writer_lock():
+        nonlocal counter
+        async with zk.recipes.SharedLock(path).writer_lock:
+            counter += 1
+            await asyncio.sleep(2)
+
+    tasks = []
+
+    tasks.append(asyncio.create_task(start_reader_lock()))
+    tasks.append(asyncio.create_task(start_reader_lock()))
+    await asyncio.sleep(0.5)
+    assert counter == 2
+    # it should wait for 2 readers release
+    tasks.append(asyncio.create_task(start_writer_lock()))
+    await asyncio.sleep(0.5)
+    assert counter == 2
+    # it should wait for prior writer release
+    tasks.append(asyncio.create_task(start_reader_lock()))
+    tasks.append(asyncio.create_task(start_reader_lock()))
+    await asyncio.sleep(0.5)
+    assert counter == 2
+    for task in tasks:
+        task.cancel()
+
+    await asyncio.gather(*tasks, return_exceptions=True)
+    await zk.deleteall(path)
+
+
+@pytest.mark.asyncio
+async def test_locked(zk, path):
+    lock = zk.recipes.SharedLock(path)
+
+    async with lock.reader_lock:
+        assert lock.reader_lock.locked()
+        assert not lock.writer_lock.locked()
+
+    assert not lock.reader_lock.locked()
+    assert not lock.writer_lock.locked()
+
+    async with lock.writer_lock:
+        assert lock.writer_lock.locked()
+        assert not lock.reader_lock.locked()
+
+    assert not lock.reader_lock.locked()
+    assert not lock.writer_lock.locked()
+
+    await zk.delete(path)
+
+
+@pytest.mark.asyncio
+async def test_same_instance_acquire_simultaneously(zk, path):
+    """simultaneous .acquire calls of the same instance are not permitted"""
+    lock = zk.recipes.SharedLock(path)
+    WORKERS = 8
+    run_counter = 0
+    acquired_counter = 0
+    cond = asyncio.Condition()
+
+    async def start_inadequate_task():
+        nonlocal run_counter
+        nonlocal acquired_counter
+        run_counter += 1
+        try:
+            async with lock.reader_lock:
+                acquired_counter += 1
+        except Exception:
+            pass
+        finally:
+            async with cond:
+                cond.notify()
+
+    async with lock.reader_lock:
+        for _ in range(WORKERS):
+            asyncio.create_task(start_inadequate_task())
+
+    async with cond:
+        await cond.wait_for(lambda: run_counter == WORKERS)
+
+    assert acquired_counter == 0
+
+    await zk.delete(path)
 
 
 @pytest.mark.asyncio
@@ -62,7 +182,7 @@ async def test_delete_unique_znode_on_timeout(zk, path):
 def inspect_waiting_loss_handlers(zk, tag):
     waitings = zk.session.state.waitings(
         states.States.LOST)[states.States.LOST]
-    tasks = [task for task in asyncio.Task.all_tasks() if not task.done()]
+    tasks = [task for task in asyncio.all_tasks() if not task.done()]
 
     print(f'({tag}) waitings={waitings}, len={len(waitings)}')
     print(f'({tag}) tasks={tasks} len={len(tasks)}')
@@ -74,16 +194,17 @@ def inspect_waiting_loss_handlers(zk, tag):
 async def test_remove_session_loss_handler_after_lock_released(zk, path):
     waitings_orig, tasks_orig = inspect_waiting_loss_handlers(zk, 'original')
     lock = zk.recipes.SharedLock(path)
-    async with await lock.acquire_write():
+    async with lock.writer_lock:
         waitings_locking, tasks_locking = inspect_waiting_loss_handlers(
             zk, 'locking')
-
+    # give a shot for tasks related to lock to be cancelled
+    await asyncio.sleep(0)
     waitings_released, tasks_released = inspect_waiting_loss_handlers(
         zk, 'released')
 
-    assert len(waitings_locking) > len(waitings_released)
+    await zk.delete(path)
+
+    assert len(waitings_locking) >= len(waitings_released)
     assert len(waitings_orig) == len(waitings_released)
     assert len(tasks_locking) > len(tasks_released)
     assert len(tasks_orig) == len(tasks_released)
-
-    await zk.delete(path)


### PR DESCRIPTION
Hello, @cybergrind 

I changed aiozk.recipes.Lock as async context manager.

So Lock recipe can be used as below.

async with zk.recipes.Lock(path):
      ...

Of course, .acquire() coroutine still works as it did.
