### PR TITLE
Fix deprecation warning

### DIFF
--- a/aiozk/test/test_barrier.py
+++ b/aiozk/test/test_barrier.py
@@ -45,9 +45,8 @@ async def test_double_barrier(zk, path):
     target = 8
     for _ in range(target):
         num_workers += 1
-        workers.append(
-            asyncio.ensure_future(start_worker(target), loop=zk.loop))
-    await asyncio.wait(workers, loop=zk.loop)
+        workers.append(zk.loop.create_task(start_worker(target)))
+    await asyncio.wait(workers)
     await zk.delete(path)
 
 

--- a/aiozk/test/test_counter.py
+++ b/aiozk/test/test_counter.py
@@ -37,7 +37,7 @@ async def test_counter_multiple(zk, path):
 
     workers = []
     for _i in range(5):
-        workers.append(worker())
+        workers.append(asyncio.create_task(worker()))
 
     done, _pending = await asyncio.wait(workers)
     assert len(done) == 5  # sanity check
@@ -57,7 +57,7 @@ async def test_counter_single_reused(zk, path):
 
     workers = []
     for _i in range(5):
-        workers.append(worker())
+        workers.append(asyncio.create_task(worker()))
 
     done, _pending = await asyncio.wait(workers)
     assert len(done) == 5

--- a/aiozk/test/test_watchers.py
+++ b/aiozk/test/test_watchers.py
@@ -114,11 +114,11 @@ async def test_child_watch(child_watcher, path, zk, child1, child2):
     child_watcher.add_callback(path, children_callback)
     assert children == set()
     await zk.create(child1)
-    await asyncio.wait([ready.wait()], timeout=0.1)
+    await asyncio.wait_for(ready.wait(), timeout=0.1)
     assert children == {child1.split('/')[-1]}
     ready.clear()
     await zk.create(child2)
-    await asyncio.wait([ready.wait()], timeout=0.1)
+    await asyncio.wait_for(ready.wait(), timeout=0.1)
     assert ready.is_set()
     assert children == {child.split('/')[-1] for child in (child1, child2)}
     child_watcher.remove_callback(path, children_callback)


### PR DESCRIPTION
`DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.`

https://docs.python.org/3/library/asyncio-task.html?highlight=wait#asyncio-example-wait-coroutine