### PR TITLE
Replace asynctest with unittest.mock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fan0/python:2.1.0
+FROM fan0/python:3.0.2
 
 WORKDIR /code
 
-RUN pip3 install fan_tools pytest-asyncio asynctest pytest-cov codecov
+RUN pip3 install fan_tools pytest-asyncio pytest-cov codecov
 RUN apt install -y tcpdump
 
 ADD . /code

--- a/aiozk/test/test_connection.py
+++ b/aiozk/test/test_connection.py
@@ -1,6 +1,5 @@
-import asyncio
+from unittest import mock
 
-import asynctest
 import pytest
 
 import aiozk.connection
@@ -11,20 +10,20 @@ def connection(event_loop):
     connection = aiozk.connection.Connection(
         host='zookeeper.test',
         port=2181,
-        watch_handler=asynctest.MagicMock(),
+        watch_handler=mock.MagicMock(),
         read_timeout=30,
-        loop=asynctest.MagicMock(wraps=event_loop))
+        loop=mock.MagicMock(wraps=event_loop))
 
-    connection.writer = asynctest.MagicMock()
+    connection.writer = mock.MagicMock()
     return connection
 
 
 @pytest.mark.asyncio
 async def test_close_connection_in_state_closing_do_not_performs_abort(connection):
-    connection.abort = asynctest.CoroutineMock()
+    connection.abort = mock.AsyncMock()
     connection.closing = True
 
-    await connection.close(asynctest.ANY)
+    await connection.close(mock.ANY)
 
     connection.abort.assert_not_awaited()
 
@@ -32,7 +31,7 @@ async def test_close_connection_in_state_closing_do_not_performs_abort(connectio
 @pytest.mark.asyncio
 async def test_close_cancels_read_loop_task(connection):
     connection.start_read_loop()
-    connection.read_response = asynctest.CoroutineMock(return_value=(0, asynctest.ANY, asynctest.ANY))
+    connection.read_response = mock.AsyncMock(return_value=(0, mock.ANY, mock.ANY))
 
     task_cancelled_future = connection.loop.create_future()
 
@@ -41,5 +40,5 @@ async def test_close_cancels_read_loop_task(connection):
 
     connection.read_loop_task.add_done_callback(set_result)
 
-    await connection.close(asynctest.ANY)
+    await connection.close(mock.ANY)
     assert await task_cancelled_future

--- a/aiozk/test/test_lock.py
+++ b/aiozk/test/test_lock.py
@@ -1,5 +1,5 @@
+from unittest import mock
 import asyncio
-import asynctest
 import logging
 import pytest
 import time
@@ -94,7 +94,7 @@ async def test_timeout_accuracy(zk, path):
         async with zk.recipes.Lock(path):
             lock2 = zk.recipes.Lock(path)
             analyze_siblings = lock2.analyze_siblings
-            lock2.analyze_siblings = asynctest.CoroutineMock()
+            lock2.analyze_siblings = mock.AsyncMock()
 
             async def slow_analyze():
                 await asyncio.sleep(0.5)

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -5,27 +5,26 @@ import aiozk.session
 from aiozk.states import States
 
 import pytest
-import asynctest
 
 from aiozk import exc, protocol
 
 
 @pytest.fixture
 def session(event_loop):
-    fake_retry_policy = asynctest.MagicMock(wraps=aiozk.session.RetryPolicy.forever())
+    fake_retry_policy = mock.MagicMock(wraps=aiozk.session.RetryPolicy.forever())
     session = aiozk.session.Session(
         'zookeeper.test',
         timeout=10,
         retry_policy=fake_retry_policy,
         allow_read_only=True,
         read_timeout=30,
-        loop=asynctest.MagicMock(wraps=event_loop),
+        loop=mock.MagicMock(wraps=event_loop),
     )
     session.state.transition_to(aiozk.session.States.CONNECTED)
-    session.conn = asynctest.MagicMock()
-    session.conn.send = asynctest.CoroutineMock()
-    session.conn.close = asynctest.CoroutineMock()
-    session.ensure_safe_state = asynctest.CoroutineMock()
+    session.conn = mock.MagicMock()
+    session.conn.send = mock.AsyncMock()
+    session.conn.close = mock.AsyncMock()
+    session.ensure_safe_state = mock.AsyncMock()
     session.set_heartbeat = mock.Mock()
     return session
 
@@ -34,7 +33,10 @@ def session(event_loop):
 def retry_policy():
     with mock.patch('aiozk.session.RetryPolicy') as rpcls:
         rp = rpcls.exponential_backoff.return_value
-        enforce = asynctest.CoroutineMock(side_effect=lambda: asyncio.sleep(0))
+
+        async def sleep_zero():
+            await asyncio.sleep(0)
+        enforce = mock.AsyncMock(side_effect=sleep_zero)
         rp.enforce = enforce
         yield rp
 
@@ -253,9 +255,9 @@ async def test_send_timeout(servers, event_loop, path):
 
 @pytest.mark.asyncio
 async def test_find_server(session, retry_policy):
-    session.make_connection = asynctest.CoroutineMock()
+    session.make_connection = mock.AsyncMock()
     conn = mock.MagicMock()
-    conn.close = asynctest.CoroutineMock()
+    conn.close = mock.AsyncMock()
     conn.start_read_only = True
     session.make_connection.return_value = conn
 


### PR DESCRIPTION
Two commits are sent by this PR.


>     Replace asynctest with unittest
>     
>     asynctest seems not maintained for over a year. And when using asynctest dozens
>     of deprecation warning messages pop out.
>     
>     Here's a sample of warning messages:
>     DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
>     
>     As of python3.8, AsyncMock is introduced by unittest.mock. So it would be
>     better to use unittest.mock in lieu of asynctest.
> 


>     Bump python to 3.8.5 of a docker image for test environment
>     
>     Use python 3.8.5 for a docker image and discard asynctest python module.
> 

Thanks,