### PR TITLE
Fix unhandled InvalidStateError in SequentialRecipe.wait_on_sibling()

### DIFF
--- a/aiozk/recipes/sequential.py
+++ b/aiozk/recipes/sequential.py
@@ -124,7 +124,7 @@ class SequentialRecipe(Recipe):
         unblocked = self.client.wait_for_events([WatchEvent.DELETED], path)
 
         exists = await self.client.exists(path=path, watch=True)
-        if not exists:
+        if not exists and not unblocked.done():
             unblocked.set_result(None)
 
         try:


### PR DESCRIPTION
In SequentialRecipe.wait_on_sibling() during the checking of the path existance it is possible the following would happen:

* SequentialRecipe.wait_on_sibling() goes to sleep awaiting self.client.exists()
* The sibling node in question is deleted
* event_dispatch is executed and the unblocked's watch_callback is executed calling unblocked.set_result()
* SequentialRecipe.wait_on_sibling() is awaken receiving false

After which SequentialRecipe.wait_on_sibling() tries to execute unblocked.set_result() and recieves asyncio.InvalidStateError exception, since the unblocked is already done by that time.